### PR TITLE
Added a function to write a type double number to the lcd

### DIFF
--- a/examples/basic_text/main.cpp
+++ b/examples/basic_text/main.cpp
@@ -28,11 +28,17 @@ int main(){
     display.setOrientation(0);
 
     // Draw text on display
+    double placeHolder {123.5};
     // After passing a pointer to display, we need to tell the function what font and text to use
     // Available fonts are listed in textRenderer's readme
     // Last we tell this function where to anchor the text
     // Anchor means top left of what we draw
-    drawText(&display, font_12x16, "TEST text", 0 ,0);
+    // Examples of drawText, drawChar and drawDouble
+    drawText(&display, font_12x16, "TEST", 0 ,0);
+    drawText(&display, font_12x16, "text", 0 ,15);
+    drawChar(&display, font_12x16, 76, 0 ,30);
+    drawDouble(&display, font_12x16, 1.1, 1, 15, 30);
+    drawDouble(&display, font_12x16, placeHolder, 1, 15, 45);
 
     // Send buffer to the display
     display.sendBuffer();

--- a/examples/basic_text/readme.md
+++ b/examples/basic_text/readme.md
@@ -1,3 +1,4 @@
 # This examples produces such a result
+Also showing should be a character 'L' and a number 1.1 and below that 123.5
 
 ![output](output.jpg)

--- a/textRenderer/TextRenderer.cpp
+++ b/textRenderer/TextRenderer.cpp
@@ -1,4 +1,7 @@
 #include "TextRenderer.h"
+#include <stdlib.h>
+#include <string.h> //memset()
+#include <cstdio>
 
 namespace pico_ssd1306 {
 
@@ -54,4 +57,36 @@ namespace pico_ssd1306 {
             }
         }
     }
+
+#define ARRAY_LEN 255
+    void drawDouble(pico_ssd1306::SSD1306 *ssd1306, const unsigned char *font, double number, uint8_t digits, uint8_t anchor_x, uint8_t anchor_y,
+                    WriteMode mode, Rotation rotation)
+    {
+        char Str[ARRAY_LEN];
+        sprintf(Str, "%.*lf", digits + 0, number);
+        char *pStr = (char *)malloc((strlen(Str)) * sizeof(char));
+        memcpy(pStr, Str, (strlen(Str) - 1));
+        *(pStr + strlen(Str) - 1) = '\0';
+        if (digits == 0)
+            *(pStr + strlen(Str) - 2) = '\0';
+
+        // show
+        uint8_t font_width = font[0];
+        uint16_t n = 0;
+        while (Str[n] != '\0') {
+            switch (rotation) {
+                case Rotation::deg0:
+                    drawChar(ssd1306, font, Str[n], anchor_x + (n * font_width), anchor_y, mode, rotation);
+                    break;
+                case Rotation::deg90:
+                    drawChar(ssd1306, font, Str[n], anchor_x, anchor_y + (n * font_width), mode, rotation);
+                    break;
+            }
+
+            n++;
+        }
+        free(pStr);
+        pStr = NULL;
+    }
+
 }

--- a/textRenderer/TextRenderer.h
+++ b/textRenderer/TextRenderer.h
@@ -37,6 +37,19 @@ namespace pico_ssd1306{
     /// \param mode - mode describes setting behavior. See WriteMode doc for more information
     /// \param rotation - either rotates the text by 90 deg or leaves it unrotated
     void drawText(pico_ssd1306::SSD1306 *ssd1306, const unsigned char * font, const char * text, uint8_t anchor_x, uint8_t anchor_y, WriteMode mode = WriteMode::ADD, Rotation rotation = Rotation::deg0);
+
+    /// \brief Draws number on screen
+    /// \param ssd1306 - pointer to a SSD1306 object aka initialised display.
+    /// \param font - pointer to a font data array.
+    /// \param number - number to be drawn.
+    /// \param scale - number of digits after the decimal place.
+    /// \param anchor_x, anchor_y - coordinates setting where to put the text.
+    /// \param mode - mode describes setting behavior. See WriteMode doc for more information.
+    /// \param rotation - either rotates the text by 90 deg or leaves it unrotated.
+
+    void drawDouble(pico_ssd1306::SSD1306 *ssd1306, const unsigned char * font, double number, uint8_t scale, uint8_t anchor_x, uint8_t anchor_y, WriteMode mode = WriteMode::ADD, Rotation rotation = Rotation::deg0);
+
+
 }
 
 #endif //SSD1306_TEXTRENDERER_H


### PR DESCRIPTION
I have updated TextRenderer.ccp and TextRenderer.h to have additional functionality.
You can write a type double number directly to the LCD, using a function called drawDouble.

The driver now has drawChar, drawText and drawDouble

I also added an example to the basic text example.

I used your driver to drive an LCD but needed a way to write real numbers on the screen, so  I added it to your driver.

you can contact me at michael@duplessis.nz

It would be fantastic if you could add my changes. 


