### PR TITLE
Fix bugs #7 and #8, input validation for ShapeRenderer and TextRenderer functions

### DIFF
--- a/frameBuffer/FrameBuffer.cpp
+++ b/frameBuffer/FrameBuffer.cpp
@@ -4,6 +4,10 @@ FrameBuffer::FrameBuffer() {
     this->buffer = new unsigned char[FRAMEBUFFER_SIZE];
 }
 
+FrameBuffer::~FrameBuffer() {
+    delete[] this->buffer;
+}
+
 void FrameBuffer::byteOR(int n, unsigned char byte) {
     // return if index outside 0 - buffer length - 1
     if (n > (FRAMEBUFFER_SIZE-1)) return;
@@ -24,6 +28,8 @@ void FrameBuffer::byteXOR(int n, unsigned char byte) {
 
 
 void FrameBuffer::setBuffer(unsigned char *new_buffer) {
+    // free buffer memory to prevent memory leak
+    delete[] this->buffer;
     this->buffer = new_buffer;
 }
 

--- a/frameBuffer/FrameBuffer.h
+++ b/frameBuffer/FrameBuffer.h
@@ -16,6 +16,9 @@ public:
     /// Constructs frame buffer and allocates memory for buffer
     FrameBuffer();
 
+    /// Destroys frame buffer and frees buffer memory
+    ~FrameBuffer();
+
     /// \brief Performs OR logical operation on selected and provided byte
     ///
     /// ex. if byte in buffer at position n is 0b10001111 and provided byte is 0b11110000 the buffer at position n becomes 0b11111111

--- a/frameBuffer/FrameBuffer.h
+++ b/frameBuffer/FrameBuffer.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef SSD1306_FRAMEBUFFER_H
 #define SSD1306_FRAMEBUFFER_H
 

--- a/shapeRenderer/ShapeRenderer.h
+++ b/shapeRenderer/ShapeRenderer.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef SSD1306_SHAPERENDERER_H
 #define SSD1306_SHAPERENDERER_H
 

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef SSD1306_SSD1306_H
 #define SSD1306_SSD1306_H
 

--- a/textRenderer/TextRenderer.cpp
+++ b/textRenderer/TextRenderer.cpp
@@ -4,6 +4,8 @@ namespace pico_ssd1306 {
 
     void drawText(pico_ssd1306::SSD1306 *ssd1306, const unsigned char *font, const char *text, uint8_t anchor_x,
                   uint8_t anchor_y, WriteMode mode, Rotation rotation) {
+        if(!ssd1306 || !font || !text) return;
+
         uint8_t font_width = font[0];
 
         uint16_t n = 0;
@@ -23,9 +25,7 @@ namespace pico_ssd1306 {
 
     void drawChar(pico_ssd1306::SSD1306 *ssd1306, const unsigned char *font, char c, uint8_t anchor_x, uint8_t anchor_y,
                   WriteMode mode, Rotation rotation) {
-
-
-        if (c < 32) return;
+        if(!ssd1306 || !font || c < 32) return;
 
         uint8_t font_width = font[0];
         uint8_t font_height = font[1];

--- a/textRenderer/TextRenderer.h
+++ b/textRenderer/TextRenderer.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef SSD1306_TEXTRENDERER_H
 #define SSD1306_TEXTRENDERER_H
 


### PR DESCRIPTION
See the title. The ShapeRenderer and TextRenderer functions now check for nullptr inputs, instead of attempting to operate normally.