### PR TITLE
Remove redundant `FrameBuffer()` construction

### DIFF
--- a/ssd1306.cpp
+++ b/ssd1306.cpp
@@ -15,9 +15,6 @@ namespace pico_ssd1306 {
             this->height = 64;
         }
 
-        // create a frame buffer
-        this->frameBuffer = FrameBuffer();
-
         // display is not inverted by default
         this->inverted = false;
 


### PR DESCRIPTION
It seems `this->frameBuffer` is already initialized before entering the body of `SSD1306()`. Therefore there is no need to construct another `FrameBuffer`. In fact, doing so can cause memory issues when `~FrameBuffer()` is called upon leaving `SSD1306()`, with the freed buffer in the deconstructed `FrameBuffer` being written to by the constructed `SSD1306` when used.

See issue #12 for more.