### PR TITLE
Added capability to turn screen on and off

### DIFF
--- a/ssd1306.cpp
+++ b/ssd1306.cpp
@@ -1,9 +1,7 @@
 #include "ssd1306.h"
 
-namespace pico_ssd1306
-{
-    SSD1306::SSD1306(i2c_inst *i2CInst, uint16_t Address, Size size)
-    {
+namespace pico_ssd1306 {
+    SSD1306::SSD1306(i2c_inst *i2CInst, uint16_t Address, Size size) {
         // Set class instanced variables
         this->i2CInst = i2CInst;
         this->address = Address;
@@ -11,12 +9,9 @@ namespace pico_ssd1306
 
         this->width = 128;
 
-        if (size == Size::W128xH32)
-        {
+        if (size == Size::W128xH32) {
             this->height = 32;
-        }
-        else
-        {
+        } else {
             this->height = 64;
         }
 
@@ -25,46 +20,46 @@ namespace pico_ssd1306
 
         // this is a list of setup commands for the display
         uint8_t setup[] = {
-            SSD1306_DISPLAY_OFF,
-            SSD1306_LOWCOLUMN,
-            SSD1306_HIGHCOLUMN,
-            SSD1306_STARTLINE,
+                SSD1306_DISPLAY_OFF,
+                SSD1306_LOWCOLUMN,
+                SSD1306_HIGHCOLUMN,
+                SSD1306_STARTLINE,
 
-            SSD1306_MEMORYMODE,
-            SSD1306_MEMORYMODE_HORZONTAL,
+                SSD1306_MEMORYMODE,
+                SSD1306_MEMORYMODE_HORZONTAL,
 
-            SSD1306_CONTRAST,
-            0xFF,
+                SSD1306_CONTRAST,
+                0xFF,
 
-            SSD1306_INVERTED_OFF,
+                SSD1306_INVERTED_OFF,
 
-            SSD1306_MULTIPLEX,
-            63,
+                SSD1306_MULTIPLEX,
+                63,
 
-            SSD1306_DISPLAYOFFSET,
-            0x00,
+                SSD1306_DISPLAYOFFSET,
+                0x00,
 
-            SSD1306_DISPLAYCLOCKDIV,
-            0x80,
+                SSD1306_DISPLAYCLOCKDIV,
+                0x80,
 
-            SSD1306_PRECHARGE,
-            0x22,
+                SSD1306_PRECHARGE,
+                0x22,
 
-            SSD1306_COMPINS,
-            0x12,
+                SSD1306_COMPINS,
+                0x12,
 
-            SSD1306_VCOMDETECT,
-            0x40,
+                SSD1306_VCOMDETECT,
+                0x40,
 
-            SSD1306_CHARGEPUMP,
-            0x14,
+                SSD1306_CHARGEPUMP,
+                0x14,
 
-            SSD1306_DISPLAYALL_ON_RESUME,
-            SSD1306_DISPLAY_ON};
+                SSD1306_DISPLAYALL_ON_RESUME,
+                SSD1306_DISPLAY_ON
+        };
 
         // send each one of the setup commands
-        for (uint8_t &command : setup)
-        {
+        for (uint8_t &command: setup) {
             this->cmd(command);
         }
 
@@ -72,13 +67,12 @@ namespace pico_ssd1306
         // if not done display shows garbage data
         this->clear();
         this->sendBuffer();
+
     }
 
-    void SSD1306::setPixel(int16_t x, int16_t y, WriteMode mode)
-    {
+    void SSD1306::setPixel(int16_t x, int16_t y, WriteMode mode) {
         // return if position out of bounds
-        if ((x < 0) || (x >= this->width) || (y < 0) || (y >= this->height))
-            return;
+        if ((x < 0) || (x >= this->width) || (y < 0) || (y >= this->height)) return;
 
         // byte to be used for buffer operation
         uint8_t byte;
@@ -86,39 +80,32 @@ namespace pico_ssd1306
         // display with 32 px height requires doubling of set bits, reason to this is explained in readme
         // this shifts 1 to byte based on y coordinate
         // remember that buffer is a one dimension array, so we have to calculate offset from coordinates
-        if (size == Size::W128xH32)
-        {
+        if (size == Size::W128xH32) {
             y = (y << 1) + 1;
             byte = 1 << (y & 7);
             char byte_offset = byte >> 1;
             byte = byte | byte_offset;
-        }
-        else
-        {
+        } else {
             byte = 1 << (y & 7);
         }
 
         // check the write mode and manipulate the frame buffer
-        if (mode == WriteMode::ADD)
-        {
+        if (mode == WriteMode::ADD) {
             this->frameBuffer.byteOR(x + (y / 8) * this->width, byte);
-        }
-        else if (mode == WriteMode::SUBTRACT)
-        {
+        } else if (mode == WriteMode::SUBTRACT) {
             this->frameBuffer.byteAND(x + (y / 8) * this->width, ~byte);
-        }
-        else if (mode == WriteMode::INVERT)
-        {
+        } else if (mode == WriteMode::INVERT) {
             this->frameBuffer.byteXOR(x + (y / 8) * this->width, byte);
         }
+
+
     }
 
-    void SSD1306::sendBuffer()
-    {
-        this->cmd(SSD1306_PAGEADDR); // Set page address from min to max
+    void SSD1306::sendBuffer() {
+        this->cmd(SSD1306_PAGEADDR); //Set page address from min to max
         this->cmd(0x00);
         this->cmd(0x07);
-        this->cmd(SSD1306_COLUMNADDR); // Set column address from min to max
+        this->cmd(SSD1306_COLUMNADDR); //Set column address from min to max
         this->cmd(0x00);
         this->cmd(127);
 
@@ -134,21 +121,16 @@ namespace pico_ssd1306
         i2c_write_blocking(this->i2CInst, this->address, data, FRAMEBUFFER_SIZE + 1, false);
     }
 
-    void SSD1306::clear()
-    {
+    void SSD1306::clear() {
         this->frameBuffer.clear();
     }
 
-    void SSD1306::setOrientation(bool orientation)
-    {
+    void SSD1306::setOrientation(bool orientation) {
         // remap columns and rows scan direction, effectively flipping the image on display
-        if (orientation)
-        {
+        if (orientation) {
             this->cmd(SSD1306_CLUMN_REMAP_OFF);
             this->cmd(SSD1306_COM_REMAP_OFF);
-        }
-        else
-        {
+        } else {
             this->cmd(SSD1306_CLUMN_REMAP_ON);
             this->cmd(SSD1306_COM_REMAP_ON);
         }
@@ -157,57 +139,48 @@ namespace pico_ssd1306
     void
     SSD1306::addBitmapImage(int16_t anchorX, int16_t anchorY, uint8_t image_width, uint8_t image_height,
                             uint8_t *image,
-                            WriteMode mode)
-    {
+                            WriteMode mode) {
         uint8_t byte;
         // goes over every single bit in image and sets pixel data on its coordinates
-        for (uint8_t y = 0; y < image_height; y++)
-        {
-            for (uint8_t x = 0; x < image_width / 8; x++)
-            {
+        for (uint8_t y = 0; y < image_height; y++) {
+            for (uint8_t x = 0; x < image_width / 8; x++) {
                 byte = image[y * (image_width / 8) + x];
-                for (uint8_t z = 0; z < 8; z++)
-                {
-                    if ((byte >> (7 - z)) & 1)
-                    {
+                for (uint8_t z = 0; z < 8; z++) {
+                    if ((byte >> (7 - z)) & 1) {
                         this->setPixel(x * 8 + z + anchorX, y + anchorY, mode);
                     }
                 }
             }
         }
+
     }
 
-    void SSD1306::invertDisplay()
-    {
+    void SSD1306::invertDisplay() {
         this->cmd(SSD1306_INVERTED_OFF | !this->inverted);
         inverted = !inverted;
     }
 
-    void SSD1306::cmd(unsigned char command)
-    {
+    void SSD1306::cmd(unsigned char command) {
         // 0x00 is a byte indicating to ssd1306 that a command is being sent
         uint8_t data[2] = {0x00, command};
         i2c_write_blocking(this->i2CInst, this->address, data, 2, false);
     }
 
-    void SSD1306::setContrast(unsigned char contrast)
-    {
+
+    void SSD1306::setContrast(unsigned char contrast) {
         this->cmd(SSD1306_CONTRAST);
         this->cmd(contrast);
     }
 
-    void SSD1306::setBuffer(unsigned char *buffer)
-    {
+    void SSD1306::setBuffer(unsigned char * buffer) {
         this->frameBuffer.setBuffer(buffer);
     }
 
-    void SSD1306::turnOff()
-    {
+    void SSD1306::turnOff() {
         this->cmd(SSD1306_DISPLAY_OFF);
     }
 
-    void SSD1306::turnOn()
-    {
+    void SSD1306::turnOn() {
         this->cmd(SSD1306_DISPLAY_ON);
     }
 

--- a/ssd1306.cpp
+++ b/ssd1306.cpp
@@ -1,7 +1,9 @@
 #include "ssd1306.h"
 
-namespace pico_ssd1306 {
-    SSD1306::SSD1306(i2c_inst *i2CInst, uint16_t Address, Size size) {
+namespace pico_ssd1306
+{
+    SSD1306::SSD1306(i2c_inst *i2CInst, uint16_t Address, Size size)
+    {
         // Set class instanced variables
         this->i2CInst = i2CInst;
         this->address = Address;
@@ -9,9 +11,12 @@ namespace pico_ssd1306 {
 
         this->width = 128;
 
-        if (size == Size::W128xH32) {
+        if (size == Size::W128xH32)
+        {
             this->height = 32;
-        } else {
+        }
+        else
+        {
             this->height = 64;
         }
 
@@ -20,46 +25,46 @@ namespace pico_ssd1306 {
 
         // this is a list of setup commands for the display
         uint8_t setup[] = {
-                SSD1306_DISPLAY_OFF,
-                SSD1306_LOWCOLUMN,
-                SSD1306_HIGHCOLUMN,
-                SSD1306_STARTLINE,
+            SSD1306_DISPLAY_OFF,
+            SSD1306_LOWCOLUMN,
+            SSD1306_HIGHCOLUMN,
+            SSD1306_STARTLINE,
 
-                SSD1306_MEMORYMODE,
-                SSD1306_MEMORYMODE_HORZONTAL,
+            SSD1306_MEMORYMODE,
+            SSD1306_MEMORYMODE_HORZONTAL,
 
-                SSD1306_CONTRAST,
-                0xFF,
+            SSD1306_CONTRAST,
+            0xFF,
 
-                SSD1306_INVERTED_OFF,
+            SSD1306_INVERTED_OFF,
 
-                SSD1306_MULTIPLEX,
-                63,
+            SSD1306_MULTIPLEX,
+            63,
 
-                SSD1306_DISPLAYOFFSET,
-                0x00,
+            SSD1306_DISPLAYOFFSET,
+            0x00,
 
-                SSD1306_DISPLAYCLOCKDIV,
-                0x80,
+            SSD1306_DISPLAYCLOCKDIV,
+            0x80,
 
-                SSD1306_PRECHARGE,
-                0x22,
+            SSD1306_PRECHARGE,
+            0x22,
 
-                SSD1306_COMPINS,
-                0x12,
+            SSD1306_COMPINS,
+            0x12,
 
-                SSD1306_VCOMDETECT,
-                0x40,
+            SSD1306_VCOMDETECT,
+            0x40,
 
-                SSD1306_CHARGEPUMP,
-                0x14,
+            SSD1306_CHARGEPUMP,
+            0x14,
 
-                SSD1306_DISPLAYALL_ON_RESUME,
-                SSD1306_DISPLAY_ON
-        };
+            SSD1306_DISPLAYALL_ON_RESUME,
+            SSD1306_DISPLAY_ON};
 
         // send each one of the setup commands
-        for (uint8_t &command: setup) {
+        for (uint8_t &command : setup)
+        {
             this->cmd(command);
         }
 
@@ -67,12 +72,13 @@ namespace pico_ssd1306 {
         // if not done display shows garbage data
         this->clear();
         this->sendBuffer();
-
     }
 
-    void SSD1306::setPixel(int16_t x, int16_t y, WriteMode mode) {
+    void SSD1306::setPixel(int16_t x, int16_t y, WriteMode mode)
+    {
         // return if position out of bounds
-        if ((x < 0) || (x >= this->width) || (y < 0) || (y >= this->height)) return;
+        if ((x < 0) || (x >= this->width) || (y < 0) || (y >= this->height))
+            return;
 
         // byte to be used for buffer operation
         uint8_t byte;
@@ -80,32 +86,39 @@ namespace pico_ssd1306 {
         // display with 32 px height requires doubling of set bits, reason to this is explained in readme
         // this shifts 1 to byte based on y coordinate
         // remember that buffer is a one dimension array, so we have to calculate offset from coordinates
-        if (size == Size::W128xH32) {
+        if (size == Size::W128xH32)
+        {
             y = (y << 1) + 1;
             byte = 1 << (y & 7);
             char byte_offset = byte >> 1;
             byte = byte | byte_offset;
-        } else {
+        }
+        else
+        {
             byte = 1 << (y & 7);
         }
 
         // check the write mode and manipulate the frame buffer
-        if (mode == WriteMode::ADD) {
+        if (mode == WriteMode::ADD)
+        {
             this->frameBuffer.byteOR(x + (y / 8) * this->width, byte);
-        } else if (mode == WriteMode::SUBTRACT) {
+        }
+        else if (mode == WriteMode::SUBTRACT)
+        {
             this->frameBuffer.byteAND(x + (y / 8) * this->width, ~byte);
-        } else if (mode == WriteMode::INVERT) {
+        }
+        else if (mode == WriteMode::INVERT)
+        {
             this->frameBuffer.byteXOR(x + (y / 8) * this->width, byte);
         }
-
-
     }
 
-    void SSD1306::sendBuffer() {
-        this->cmd(SSD1306_PAGEADDR); //Set page address from min to max
+    void SSD1306::sendBuffer()
+    {
+        this->cmd(SSD1306_PAGEADDR); // Set page address from min to max
         this->cmd(0x00);
         this->cmd(0x07);
-        this->cmd(SSD1306_COLUMNADDR); //Set column address from min to max
+        this->cmd(SSD1306_COLUMNADDR); // Set column address from min to max
         this->cmd(0x00);
         this->cmd(127);
 
@@ -121,16 +134,21 @@ namespace pico_ssd1306 {
         i2c_write_blocking(this->i2CInst, this->address, data, FRAMEBUFFER_SIZE + 1, false);
     }
 
-    void SSD1306::clear() {
+    void SSD1306::clear()
+    {
         this->frameBuffer.clear();
     }
 
-    void SSD1306::setOrientation(bool orientation) {
+    void SSD1306::setOrientation(bool orientation)
+    {
         // remap columns and rows scan direction, effectively flipping the image on display
-        if (orientation) {
+        if (orientation)
+        {
             this->cmd(SSD1306_CLUMN_REMAP_OFF);
             this->cmd(SSD1306_COM_REMAP_OFF);
-        } else {
+        }
+        else
+        {
             this->cmd(SSD1306_CLUMN_REMAP_ON);
             this->cmd(SSD1306_COM_REMAP_ON);
         }
@@ -139,41 +157,58 @@ namespace pico_ssd1306 {
     void
     SSD1306::addBitmapImage(int16_t anchorX, int16_t anchorY, uint8_t image_width, uint8_t image_height,
                             uint8_t *image,
-                            WriteMode mode) {
+                            WriteMode mode)
+    {
         uint8_t byte;
         // goes over every single bit in image and sets pixel data on its coordinates
-        for (uint8_t y = 0; y < image_height; y++) {
-            for (uint8_t x = 0; x < image_width / 8; x++) {
+        for (uint8_t y = 0; y < image_height; y++)
+        {
+            for (uint8_t x = 0; x < image_width / 8; x++)
+            {
                 byte = image[y * (image_width / 8) + x];
-                for (uint8_t z = 0; z < 8; z++) {
-                    if ((byte >> (7 - z)) & 1) {
+                for (uint8_t z = 0; z < 8; z++)
+                {
+                    if ((byte >> (7 - z)) & 1)
+                    {
                         this->setPixel(x * 8 + z + anchorX, y + anchorY, mode);
                     }
                 }
             }
         }
-
     }
 
-    void SSD1306::invertDisplay() {
+    void SSD1306::invertDisplay()
+    {
         this->cmd(SSD1306_INVERTED_OFF | !this->inverted);
         inverted = !inverted;
     }
 
-    void SSD1306::cmd(unsigned char command) {
+    void SSD1306::cmd(unsigned char command)
+    {
         // 0x00 is a byte indicating to ssd1306 that a command is being sent
         uint8_t data[2] = {0x00, command};
         i2c_write_blocking(this->i2CInst, this->address, data, 2, false);
     }
 
-
-    void SSD1306::setContrast(unsigned char contrast) {
+    void SSD1306::setContrast(unsigned char contrast)
+    {
         this->cmd(SSD1306_CONTRAST);
         this->cmd(contrast);
     }
 
-    void SSD1306::setBuffer(unsigned char * buffer) {
+    void SSD1306::setBuffer(unsigned char *buffer)
+    {
         this->frameBuffer.setBuffer(buffer);
+    }
+
+    void SSD1306::turnOff()
+    {
+        this->cmd(SSD1306_DISPLAY_OFF);
+    }
+
+    void SSD1306::turnOn()
+    {
+        this->cmd(SSD1306_DISPLAY_ON);
     }
 
 }

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -5,9 +5,11 @@
 #include "hardware/i2c.h"
 #include "frameBuffer/FrameBuffer.h"
 
-namespace pico_ssd1306 {
+namespace pico_ssd1306
+{
     /// Register addresses from datasheet
-    enum REG_ADDRESSES : unsigned char{
+    enum REG_ADDRESSES : unsigned char
+    {
         SSD1306_CONTRAST = 0x81,
         SSD1306_DISPLAYALL_ON_RESUME = 0xA4,
         SSD1306_DISPLAYALL_ON = 0xA5,
@@ -40,7 +42,8 @@ namespace pico_ssd1306 {
     };
 
     /// \enum pico_ssd1306::Size
-    enum class Size {
+    enum class Size
+    {
         /// Display size W128xH64
         W128xH64,
         /// Display size W128xH32
@@ -48,7 +51,8 @@ namespace pico_ssd1306 {
     };
 
     /// \enum pico_ssd1306::WriteMode
-    enum class WriteMode : const unsigned char{
+    enum class WriteMode : const unsigned char
+    {
         /// sets pixel on regardless of its state
         ADD = 0,
         /// sets pixel off regardless of its state
@@ -59,7 +63,8 @@ namespace pico_ssd1306 {
 
     /// \class SSD1306 ssd1306.h "pico-ssd1306/ssd1306.h"
     /// \brief SSD1306 class represents i2c connection to display
-    class SSD1306 {
+    class SSD1306
+    {
     private:
         i2c_inst *i2CInst;
         uint16_t address;
@@ -111,7 +116,6 @@ namespace pico_ssd1306 {
         /// \param orientation - 0 for not flipped, 1 for flipped display
         void setOrientation(bool orientation);
 
-
         /// \brief Clears frame buffer aka set all bytes to 0
         void clear();
 
@@ -121,8 +125,14 @@ namespace pico_ssd1306 {
         /// \brief Sets display contrast according to ssd1306 documentation
         /// \param contrast - accepted values of 0 to 255 to set the contrast
         void setContrast(unsigned char contrast);
+
+        /// \brief Turns display off
+        void turnOff();
+
+        /// \brief Turns display on
+        void turnOn();
     };
 
 }
 
-#endif //SSD1306_SSD1306_H
+#endif // SSD1306_SSD1306_H

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -5,11 +5,9 @@
 #include "hardware/i2c.h"
 #include "frameBuffer/FrameBuffer.h"
 
-namespace pico_ssd1306
-{
+namespace pico_ssd1306 {
     /// Register addresses from datasheet
-    enum REG_ADDRESSES : unsigned char
-    {
+    enum REG_ADDRESSES : unsigned char{
         SSD1306_CONTRAST = 0x81,
         SSD1306_DISPLAYALL_ON_RESUME = 0xA4,
         SSD1306_DISPLAYALL_ON = 0xA5,
@@ -42,8 +40,7 @@ namespace pico_ssd1306
     };
 
     /// \enum pico_ssd1306::Size
-    enum class Size
-    {
+    enum class Size {
         /// Display size W128xH64
         W128xH64,
         /// Display size W128xH32
@@ -51,8 +48,7 @@ namespace pico_ssd1306
     };
 
     /// \enum pico_ssd1306::WriteMode
-    enum class WriteMode : const unsigned char
-    {
+    enum class WriteMode : const unsigned char{
         /// sets pixel on regardless of its state
         ADD = 0,
         /// sets pixel off regardless of its state
@@ -63,8 +59,7 @@ namespace pico_ssd1306
 
     /// \class SSD1306 ssd1306.h "pico-ssd1306/ssd1306.h"
     /// \brief SSD1306 class represents i2c connection to display
-    class SSD1306
-    {
+    class SSD1306 {
     private:
         i2c_inst *i2CInst;
         uint16_t address;
@@ -116,6 +111,7 @@ namespace pico_ssd1306
         /// \param orientation - 0 for not flipped, 1 for flipped display
         void setOrientation(bool orientation);
 
+
         /// \brief Clears frame buffer aka set all bytes to 0
         void clear();
 
@@ -135,4 +131,4 @@ namespace pico_ssd1306
 
 }
 
-#endif // SSD1306_SSD1306_H
+#endif //SSD1306_SSD1306_H


### PR DESCRIPTION
# Feature Added

Added the feature to programmatically turn the display on or off.

# Reason

For a typical continuously operated device, it does not make sense to have the screen "on" continuously, as this results in reduced life of the screen and increases power consumption. This was the main inspiration for this change.

# Changes Made

Added two methods `turnOff` and `turnOn` to `SSD1306` class. These methods send `SSD1306_DISPLAY_OFF` and `SSD1306_DISPLAY_ON` commands respectively to the display.

This was tested in my Pico board and worked as expected.

Please feel free to let me know should you need any further changes.