### PR TITLE
CMakeLists.txt changes to build as self-contained library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,3 @@ target_sources(pico-ssd1306 INTERFACE
 
 target_include_directories(pico-ssd1306 INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
-#target_link_libraries(pico_ssd1306
-#        ssd1306_textRenderer
-#        hardware_i2c
-#        pico_stdlib
-#        )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,7 @@ target_sources(pico-ssd1306 INTERFACE
 
 target_include_directories(pico-ssd1306 INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
+# Link to pico_stdlib (gpio, time, etc. functions)
+target_link_libraries(${PROJECT_NAME} INTERFACE
+    hardware_i2c
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(textRenderer)
 target_sources(${PROJECT_NAME} INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/ssd1306.cpp
         ${CMAKE_CURRENT_LIST_DIR}/framebuffer/framebuffer.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/shapeRenderer/ShapeRenderer.cpp
 )
 
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,20 +9,22 @@ project(pico-ssd1306
     DESCRIPTION "SSD1306 Library for RP2040"
 )
 
-add_library(pico-ssd1306 INTERFACE
-        ssd1306.cpp
-        frameBuffer/FrameBuffer.cpp
-        shapeRenderer/ShapeRenderer.cpp)
+add_library(${PROJECT_NAME} INTERFACE
+    ssd1306.cpp
+    frameBuffer/FrameBuffer.cpp
+    shapeRenderer/ShapeRenderer.cpp)
 
 add_subdirectory(textRenderer)
 
-target_sources(pico-ssd1306 INTERFACE
+target_sources(${PROJECT_NAME} INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/ssd1306.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/framebuffer/framebuffer.cpp
 )
 
-target_include_directories(pico-ssd1306 INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
 # Link to pico_stdlib (gpio, time, etc. functions)
 target_link_libraries(${PROJECT_NAME} INTERFACE
     hardware_i2c
+    ssd1306_textRenderer
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,29 @@
-add_library(pico_ssd1306
+
+cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+project(pico-ssd1306
+    VERSION 1.0.0
+    DESCRIPTION "SSD1306 Library for RP2040"
+)
+
+add_library(pico-ssd1306 INTERFACE
         ssd1306.cpp
         frameBuffer/FrameBuffer.cpp
         shapeRenderer/ShapeRenderer.cpp)
 
 add_subdirectory(textRenderer)
 
-target_link_libraries(pico_ssd1306
-        ssd1306_textRenderer
-        hardware_i2c
-        pico_stdlib
-        )
-target_include_directories (pico_ssd1306 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_sources(pico-ssd1306 INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/ssd1306.cpp
+)
+
+target_include_directories(pico-ssd1306 INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+#target_link_libraries(pico_ssd1306
+#        ssd1306_textRenderer
+#        hardware_i2c
+#        pico_stdlib
+#        )

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,8 @@
   ```cmake
     add_subdirectory(pico-ssd1306)
     target_link_libraries(${PROJECT_NAME}
-    pico_ssd1306)
+        pico_ssd1306
+    )
   ```
 * Import library in your code
   ```c++

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 * Add this to your CMakeLists.txt
   ```cmake
     add_subdirectory(pico-ssd1306)
-    target_link_libraries(your_project_name
+    target_link_libraries(${PROJECT_NAME}
     pico_ssd1306)
   ```
 * Import library in your code

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,7 @@
   ```cmake
     add_subdirectory(pico-ssd1306)
     target_link_libraries(your_project_name
-    pico_ssd1306
-    # you will also need hardware i2c library for communication with the display
-    hardware_i2c)
+    pico_ssd1306)
   ```
 * Import library in your code
   ```c++

--- a/ssd1306.cpp
+++ b/ssd1306.cpp
@@ -17,7 +17,9 @@ namespace pico_ssd1306 {
 
         // display is not inverted by default
         this->inverted = false;
+    }
 
+    void SSD1306::begin() {
         // this is a list of setup commands for the display
         uint8_t setup[] = {
                 SSD1306_DISPLAY_OFF,

--- a/ssd1306.cpp
+++ b/ssd1306.cpp
@@ -168,7 +168,6 @@ namespace pico_ssd1306 {
         i2c_write_blocking(this->i2CInst, this->address, data, 2, false);
     }
 
-
     void SSD1306::setContrast(unsigned char contrast) {
         this->cmd(SSD1306_CONTRAST);
         this->cmd(contrast);

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -82,6 +82,9 @@ namespace pico_ssd1306 {
         /// \param size - display size. Acceptable values W128xH32 or W128xH64
         SSD1306(i2c_inst *i2CInst, uint16_t Address, Size size);
 
+        /// \brief Initialize the class instance after calling constructor
+        void begin();
+
         /// \brief Set pixel operates frame buffer
         /// x is the x position of pixel you want to change. values 0 - 127
         /// y is the y position of pixel you want to change. values 0 - 31 or 0 - 63


### PR DESCRIPTION
Modified CMakeLists.txt for the project to be built as a self contained library.  This allows it to be included in the main project CMakeLists.txt without having to include the pico-sdk libraries or anything additional outside of just including the library.