### PR TITLE
Simplify constructor use and documentation improvement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ gpio_pull_up(I2C_PIN_SDA);
 gpio_pull_up(I2C_PIN_SCL);
 
 //Create a new display object
-pico_ssd1306::SSD1306 display = pico_ssd1306::SSD1306(I2C_PORT, 0x3D, pico_ssd1306::Size::W128xH64);
+pico_ssd1306::SSD1306 display(I2C_PORT, 0x3D, pico_ssd1306::Size::W128xH64);
 
 //create a vertical line on x: 64 y:0-63
 for (int y = 0; y < 64; y++){

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -82,6 +82,13 @@ namespace pico_ssd1306 {
         /// \param size - display size. Acceptable values W128xH32 or W128xH64
         SSD1306(i2c_inst *i2CInst, uint16_t Address, Size size);
 
+#if __cplusplus >= 201103L
+	/// \brief SSD1306 constructor with implied standard address.
+        /// \param i2CInst - i2c instance. Either i2c0 or i2c1
+        /// \param size - display size. Acceptable values W128xH32 or W128xH64
+        SSD1306(i2c_inst *i2CInst, Size size) : SSD1306(i2CInst, size == Size::W128xH32 ? 0x3C : 0x3D, size) { }
+#endif
+
         /// \brief Set pixel operates frame buffer
         /// x is the x position of pixel you want to change. values 0 - 127
         /// y is the y position of pixel you want to change. values 0 - 31 or 0 - 63


### PR DESCRIPTION
The SSD1306 constructor should not require duplicated information and bleeding of details (i.e., the I²C address) into the application code.

The documentation shows an inefficient use to construct the SSD1306 object. A minimal change does away with that and removes the superfluous double use of the full type name (alternative: use `auto`).